### PR TITLE
Rename the Makefile target "fmt" to "format"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ publish-lint:
 	twine check dist/*
 
 
-.PHONY: format
-format:
+.PHONY: fmt format
+fmt format:
 	isort $(ISORT_DIRS)
 	black $(BLACK_DIRS)
 


### PR DESCRIPTION
In all other repositories we use target `format`.