### PR TITLE
Fix transfer of build-arg into build image job

### DIFF
--- a/neuro_flow/live_runner.py
+++ b/neuro_flow/live_runner.py
@@ -469,7 +469,7 @@ class LiveRunner(AsyncContextManager["LiveRunner"]):
         )
         cmd.append(f"--file={rel_dockerfile_path}")
         for arg in image_ctx.build_args:
-            cmd.append(f"--build-arg=arg")
+            cmd.append(f"--build-arg={arg}")
         cmd.append(str(image_ctx.full_context_path))
         cmd.append(str(image_ctx.ref))
         await self._run_subproc("neuro-extras", "image", "build", *cmd)


### PR DESCRIPTION
Missed placeholder brackets while formatting `cmd` string in [live_runner.py:build](https://github.com/neuromation/neuro-flow/blob/master/neuro_flow/live_runner.py#L472) method.