### PR TITLE
Refactor storage

### DIFF
--- a/neuro_flow/batch_runner.py
+++ b/neuro_flow/batch_runner.py
@@ -376,7 +376,9 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
         bake = await self._storage.fetch_bake_by_id(self.project, bake_id)
         attempt = await self._storage.find_attempt(bake, attempt_no)
         if attempt.result in TERMINATED_JOB_STATUSES:
-            raise click.BadArgumentUsage(f"This bake attempt is already stopped.")
+            raise click.BadArgumentUsage(
+                f"Attempt #{attempt.number} of {bake.bake_id} is already stopped."
+            )
         await self._storage.finish_attempt(attempt, JobStatus.CANCELLED)
         click.echo(f"Attempt #{attempt.number} of bake {bake.bake_id} was cancelled.")
 
@@ -395,3 +397,23 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
 
     async def clear_cache(self, batch: Optional[str] = None) -> None:
         await self._storage.clear_cache(self.project, batch)
+
+    async def rerun(
+        self, bake_id: str, *, attempt_no: int = -1, from_failed: bool = True
+    ) -> None:
+        bake = await self._storage.fetch_bake_by_id(self.project, bake_id)
+        attempt = await self._storage.find_attempt(bake, attempt_no)
+        if attempt.result not in TERMINATED_JOB_STATUSES:
+            raise click.BadArgumentUsage(
+                f"Cannot re-run still running attempt #{attempt.number} "
+                f"of {bake.bake_id}."
+            )
+        if attempt.number >= 99:
+            raise click.BadArgumentUsage(
+                f"Cannot re-run {bake.bake_id}, the number of attempts exceeded."
+            )
+        await self._storage.create_attempt(bake, attempt.number + 1)
+        if from_failed:
+            started, finished = await self._storage.fetch_attempt(attempt)
+        await self._storage.finish_attempt(attempt, JobStatus.CANCELLED)
+        click.echo(f"Attempt #{attempt.number} of bake {bake.bake_id} was cancelled.")

--- a/neuro_flow/batch_runner.py
+++ b/neuro_flow/batch_runner.py
@@ -397,23 +397,3 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
 
     async def clear_cache(self, batch: Optional[str] = None) -> None:
         await self._storage.clear_cache(self.project, batch)
-
-    async def rerun(
-        self, bake_id: str, *, attempt_no: int = -1, from_failed: bool = True
-    ) -> None:
-        bake = await self._storage.fetch_bake_by_id(self.project, bake_id)
-        attempt = await self._storage.find_attempt(bake, attempt_no)
-        if attempt.result not in TERMINATED_JOB_STATUSES:
-            raise click.BadArgumentUsage(
-                f"Cannot re-run still running attempt #{attempt.number} "
-                f"of {bake.bake_id}."
-            )
-        if attempt.number >= 99:
-            raise click.BadArgumentUsage(
-                f"Cannot re-run {bake.bake_id}, the number of attempts exceeded."
-            )
-        await self._storage.create_attempt(bake, attempt.number + 1)
-        if from_failed:
-            started, finished = await self._storage.fetch_attempt(attempt)
-        await self._storage.finish_attempt(attempt, JobStatus.CANCELLED)
-        click.echo(f"Attempt #{attempt.number} of bake {bake.bake_id} was cancelled.")

--- a/neuro_flow/storage.py
+++ b/neuro_flow/storage.py
@@ -54,10 +54,10 @@ if sys.version_info < (3, 7):
 log = logging.getLogger(__name__)
 
 STARTED_RE: Final = re.compile(
-    r"\A\d+\.(?P<id>[a-zA-Z][a-zA-Z0-9_\-\.]*).started.json\Z"
+    r"\A(?P<no>\d+)\.(?P<id>[a-zA-Z][a-zA-Z0-9_\-\.]*).started.json\Z"
 )
 FINISHED_RE: Final = re.compile(
-    r"\A\d+\.(?P<id>[a-zA-Z][a-zA-Z0-9_\-\.]*).finished.json\Z"
+    r"\A(?P<no>\d+)\.(?P<id>[a-zA-Z][a-zA-Z0-9_\-\.]*).finished.json\Z"
 )
 DIGITS = 4
 
@@ -96,6 +96,7 @@ class Attempt:
 class StartedTask:
     attempt: Attempt
     id: FullID
+    number: int
     raw_id: str
     created_at: datetime.datetime
     when: datetime.datetime
@@ -105,6 +106,7 @@ class StartedTask:
 class FinishedTask:
     attempt: Attempt
     id: FullID
+    number: int
     raw_id: str
     when: datetime.datetime
     status: TaskStatus
@@ -569,9 +571,12 @@ class BatchFSStorage(BatchStorage):
                 data = await self._read_json(attempt_url / fname)
                 assert match.group("id") == data["id"]
                 full_id = _id_from_json(data["id"])
+
+                # TODO: assert data['number'] == int(match.group('no'))
                 started[full_id] = StartedTask(
                     attempt=attempt,
                     id=full_id,
+                    number=int(match.group("no")),
                     raw_id=data["raw_id"],
                     created_at=datetime.datetime.fromisoformat(data["created_at"]),
                     when=datetime.datetime.fromisoformat(data["when"]),
@@ -582,9 +587,11 @@ class BatchFSStorage(BatchStorage):
                 data = await self._read_json(attempt_url / fname)
                 assert match.group("id") == data["id"]
                 full_id = _id_from_json(data["id"])
+                # TODO: assert data['number'] == int(match.group('no'))
                 finished[full_id] = FinishedTask(
                     attempt=attempt,
                     id=full_id,
+                    number=int(match.group("no")),
                     raw_id=data["raw_id"],
                     when=datetime.datetime.fromisoformat(data["when"]),
                     status=TaskStatus(data["status"]),
@@ -615,26 +622,17 @@ class BatchFSStorage(BatchStorage):
         task_id: FullID,
         descr: JobDescription,
     ) -> StartedTask:
-        assert 0 <= task_no < int("9" * DIGITS) - 1, task_no
-        bake_uri = _mk_bake_uri(self._fs, attempt.bake)
-        attempt_url = bake_uri / f"{attempt.number:02d}.attempt"
-        pre = str(task_no + 1).zfill(DIGITS)
         assert descr.history.created_at is not None
         ret = StartedTask(
             attempt=attempt,
             id=task_id,
+            number=task_no,
             raw_id=descr.id,
             when=datetime.datetime.now(datetime.timezone.utc),
             created_at=descr.history.created_at,
         )
 
-        data = {
-            "id": _id_to_json(ret.id),
-            "raw_id": ret.raw_id,
-            "when": ret.when.isoformat(timespec="seconds"),
-            "created_at": ret.created_at.isoformat(timespec="seconds"),
-        }
-        await self._write_json(attempt_url / f"{pre}.{data['id']}.started.json", data)
+        await self.write_start(ret)
         return ret
 
     async def start_batch_action(
@@ -644,25 +642,16 @@ class BatchFSStorage(BatchStorage):
         task_id: FullID,
     ) -> StartedTask:
         assert 0 <= task_no < int("9" * DIGITS) - 1, task_no
-        bake_uri = _mk_bake_uri(self._fs, attempt.bake)
-        attempt_url = bake_uri / f"{attempt.number:02d}.attempt"
-        pre = str(task_no + 1).zfill(DIGITS)
         now = datetime.datetime.now(datetime.timezone.utc)
         ret = StartedTask(
             attempt=attempt,
             id=task_id,
+            number=task_no,
             raw_id="",
             when=now,
             created_at=now,
         )
-
-        data = {
-            "id": _id_to_json(ret.id),
-            "raw_id": ret.raw_id,
-            "when": ret.when.isoformat(timespec="seconds"),
-            "created_at": ret.created_at.isoformat(timespec="seconds"),
-        }
-        await self._write_json(attempt_url / f"{pre}.{data['id']}.started.json", data)
+        await self.write_start(ret)
         return ret
 
     async def finish_task(
@@ -681,6 +670,7 @@ class BatchFSStorage(BatchStorage):
         ret = FinishedTask(
             attempt=attempt,
             id=task.id,
+            number=task_no,
             raw_id=task.raw_id,
             when=datetime.datetime.now(datetime.timezone.utc),
             status=TaskStatus(descr.history.status),
@@ -692,18 +682,32 @@ class BatchFSStorage(BatchStorage):
             finish_description=descr.history.description,
             outputs=outputs,
         )
-        await self._write_finish(attempt, task_no, ret)
+        await self.write_finish(ret)
         return ret
 
-    async def _write_finish(
-        self, attempt: Attempt, task_no: int, ft: FinishedTask
-    ) -> None:
-        assert 0 <= task_no < int("9" * DIGITS) - 1, task_no
-        bake_uri = _mk_bake_uri(self._fs, attempt.bake)
-        attempt_url = bake_uri / f"{attempt.number:02d}.attempt"
-        pre = str(task_no + 1).zfill(DIGITS)
+    async def write_start(self, st: StartedTask) -> None:
+        assert 0 <= st.number < int("9" * DIGITS) - 1, st.number
+        bake_uri = _mk_bake_uri(self._fs, st.attempt.bake)
+        attempt_url = bake_uri / f"{st.attempt.number:02d}.attempt"
+        pre = str(st.number + 1).zfill(DIGITS)
+
+        data = {
+            "id": _id_to_json(st.id),
+            "number": st.number,
+            "raw_id": st.raw_id,
+            "when": st.when.isoformat(timespec="seconds"),
+            "created_at": st.created_at.isoformat(timespec="seconds"),
+        }
+        await self._write_json(attempt_url / f"{pre}.{data['id']}.started.json", data)
+
+    async def write_finish(self, ft: FinishedTask) -> None:
+        assert 0 <= ft.number < int("9" * DIGITS) - 1, ft.number
+        bake_uri = _mk_bake_uri(self._fs, ft.attempt.bake)
+        attempt_url = bake_uri / f"{ft.attempt.number:02d}.attempt"
+        pre = str(ft.number + 1).zfill(DIGITS)
         data = {
             "id": _id_to_json(ft.id),
+            "number": ft.number,
             "raw_id": ft.raw_id,
             "when": ft.when.isoformat(timespec="seconds"),
             "status": ft.status.value,
@@ -733,6 +737,7 @@ class BatchFSStorage(BatchStorage):
         ret = FinishedTask(
             attempt=attempt,
             id=task.id,
+            number=task_no,
             raw_id="",
             when=now,
             status=status,
@@ -744,7 +749,7 @@ class BatchFSStorage(BatchStorage):
             finish_description="",
             outputs=result.outputs,
         )
-        await self._write_finish(attempt, task_no, ret)
+        await self.write_finish(ret)
         return ret
 
     async def skip_task(
@@ -753,23 +758,22 @@ class BatchFSStorage(BatchStorage):
         task_no: int,
         task_id: FullID,
     ) -> FinishedTask:
-        assert 0 <= task_no < int("9" * DIGITS) - 1, task_no
-        bake_uri = _mk_bake_uri(self._fs, attempt.bake)
-        attempt_url = bake_uri / f"{attempt.number:02d}.attempt"
-        pre = str(task_no + 1).zfill(DIGITS)
         now = datetime.datetime.now(datetime.timezone.utc)
 
-        data = {
-            "id": _id_to_json(task_id),
-            "raw_id": "",
-            "when": now.isoformat(timespec="seconds"),
-            "created_at": now.isoformat(timespec="seconds"),
-        }
-        await self._write_json(attempt_url / f"{pre}.{data['id']}.started.json", data)
+        st = StartedTask(
+            attempt=attempt,
+            id=task_id,
+            number=task_no,
+            raw_id="",
+            when=now,
+            created_at=now,
+        )
+        await self.write_start(st)
 
         ret = FinishedTask(
             attempt=attempt,
             id=task_id,
+            number=task_no + 1,
             raw_id="",
             when=now,
             status=TaskStatus.SKIPPED,
@@ -781,7 +785,7 @@ class BatchFSStorage(BatchStorage):
             finish_description="",
             outputs={},
         )
-        await self._write_finish(attempt, task_no, ret)
+        await self.write_finish(ret)
         return ret
 
     async def check_cache(
@@ -816,6 +820,7 @@ class BatchFSStorage(BatchStorage):
             ret = FinishedTask(
                 attempt=attempt,
                 id=task_id,
+                number=task_no,
                 raw_id=data["raw_id"],
                 when=datetime.datetime.fromisoformat(data["when"]),
                 status=TaskStatus(data["status"]),
@@ -827,7 +832,7 @@ class BatchFSStorage(BatchStorage):
                 finish_description=data["finish_description"],
                 outputs=data["outputs"],
             )
-            await self._write_finish(attempt, task_no, ret)
+            await self.write_finish(ret)
             return ret
         except (KeyError, ValueError, TypeError):
             # something is wrong with stored JSON,


### PR DESCRIPTION
1. Provide a number for each task record; it allows recreating the same folder structure easily for rerun-from-failed command
2. Simplify started/finished tasks reading/writing