### PR TITLE
Properly import AsyncExitStack on python 3.6

### DIFF
--- a/neuro_flow/cli/click_types.py
+++ b/neuro_flow/cli/click_types.py
@@ -1,7 +1,7 @@
 import abc
 import click
 import operator
-from contextlib import AsyncExitStack
+import sys
 from neuromation.api import get as api_get
 from neuromation.cli.asyncio_utils import Runner
 from typing import Callable, Generic, List, Optional, Sequence, Tuple, TypeVar, cast
@@ -11,6 +11,11 @@ from neuro_flow.live_runner import LiveRunner
 from neuro_flow.parser import ConfigDir
 from neuro_flow.storage import BatchFSStorage, BatchStorage, NeuroStorageFS
 
+
+if sys.version_info >= (3, 7):
+    from contextlib import AsyncExitStack
+else:
+    from async_exit_stack import AsyncExitStack
 
 _T = TypeVar("_T")
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,6 @@
+def test_imports_ok() -> None:
+    # This test verifies that cli at least imports properly on
+    # in all supported envs and python versions
+    #
+    # Will be replaced with some proper e2e tests
+    import neuro_flow.cli  # noqa


### PR DESCRIPTION
Closes https://github.com/neuro-inc/neuro-flow/issues/116