### PR TITLE
Remove env and tags from action contexts

### DIFF
--- a/tests/e2e/test_live.py
+++ b/tests/e2e/test_live.py
@@ -57,6 +57,7 @@ def test_live_context(ws: pathlib.Path, run_cli: RunCLI, project_id: str):
                 "full_context_path": str(ws),
                 "dockerfile": str(ws / "Dockerfile"),
                 "full_dockerfile_path": str(ws / "Dockerfile"),
+                "build_preset": None,
                 "build_args": [],
                 "env": {},
                 "volumes": [],

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -208,6 +208,7 @@ async def test_pipeline_minimal_ctx(batch_config_loader: ConfigLoader) -> None:
         "tag-2",
         "tag-a",
         "tag-b",
+        "task:test-a",
         "project:unit",
         "flow:batch-minimal",
     }


### PR DESCRIPTION
Closes https://github.com/neuro-inc/neuro-flow/issues/218.
I also changed tags behavior a little: before it worked in the following way: 
When a task (in _batch_ mode) defined `.tags` attribute, the system generated tag (`task:task-id`) would **not** be added. Now it will be always added.