### PR TITLE
Add inspect_job function

### DIFF
--- a/CHANGELOG.D/255.feature
+++ b/CHANGELOG.D/255.feature
@@ -1,0 +1,1 @@
+Implement `inspect_job()` expression function.

--- a/tests/unit/test_functions.py
+++ b/tests/unit/test_functions.py
@@ -1,10 +1,13 @@
 # test functions available in expressions
+import pathlib
+import pytest
 import sys
 from neuro_sdk import Client
 from re_assert import Matches
-from typing import AsyncIterator, Mapping
+from typing import AbstractSet, Any, AsyncIterator, Callable, Mapping
 
-from neuro_flow.expr import RootABC, StrExpr, TypeT
+from neuro_flow.context import FlowCtx, LiveContext, TagsCtx
+from neuro_flow.expr import EvalError, RootABC, StrExpr, TypeT
 from neuro_flow.tokenizer import Pos
 from neuro_flow.types import LocalPath
 
@@ -112,3 +115,129 @@ async def test_parse_volume_local_full(client: Client) -> None:
     )
     ret = await expr.eval(Root({}, client))
     assert ret == "None"
+
+
+LiveContextFactory = Callable[[Client, TagsCtx], LiveContext]
+
+
+@pytest.fixture
+async def live_context_factory(assets: pathlib.Path) -> LiveContextFactory:
+    def _factory(client: Client, tags: TagsCtx = frozenset()):
+        return LiveContext(
+            _client=client,
+            flow=FlowCtx(
+                flow_id="live",
+                project_id="test",
+                workspace=assets,
+                title="unit test flow",
+            ),
+            env={},
+            images={},
+            volumes={},
+            tags=tags,
+        )
+
+    return _factory
+
+
+async def test_inspect_job_bad_context(client: Client) -> None:
+    expr = StrExpr(POS, POS, "${{ inspect_job(22) }}")
+    with pytest.raises(
+        EvalError, match=r"inspect_job\(\) is only available inside a job definition"
+    ):
+        await expr.eval(Root({}, client))
+
+
+async def test_inspect_job_bad_first_arg(
+    client: Client, live_context_factory: LiveContextFactory
+) -> None:
+    expr = StrExpr(POS, POS, "${{ inspect_job(22) }}")
+    ctx = live_context_factory(client, set())
+    with pytest.raises(
+        EvalError, match=r"inspect_job\(\) job_name argument should be a str, got 22"
+    ):
+        await expr.eval(ctx)
+
+
+async def test_inspect_job_bad_second_arg(
+    client: Client, live_context_factory: LiveContextFactory
+) -> None:
+    expr = StrExpr(POS, POS, "${{ inspect_job('foo', 22) }}")
+    ctx = live_context_factory(client, set())
+    with pytest.raises(
+        EvalError, match=r"inspect_job\(\) suffix argument should be a str, got 22"
+    ):
+        await expr.eval(ctx)
+
+
+async def test_inspect_job_correct_set_of_tags(
+    client: Client, live_context_factory: LiveContextFactory
+) -> None:
+    called = False
+
+    async def fake_list(
+        *args: Any, tags: AbstractSet[str], **kwargs: Any
+    ) -> AsyncIterator[Any]:
+        nonlocal called
+        called = True
+        assert tags == {"test_tag", "job:foo"}
+        yield {"id": "test_id"}
+
+    client.jobs.list = fake_list
+
+    expr = StrExpr(POS, POS, "${{ inspect_job('foo').id }}")
+
+    ctx = live_context_factory(client, {"test_tag"})
+    result = await expr.eval(ctx)
+    assert result == "test_id"
+    assert called
+
+
+async def test_inspect_job_correct_set_of_tags_multi(
+    client: Client, live_context_factory: LiveContextFactory
+) -> None:
+    called = False
+
+    async def fake_list(
+        *args: Any, tags: AbstractSet[str], **kwargs: Any
+    ) -> AsyncIterator[Any]:
+        nonlocal called
+        called = True
+        assert tags == {"test_tag", "job:foo", "multi:bar"}
+        yield {"id": "test_id"}
+
+    client.jobs.list = fake_list
+
+    expr = StrExpr(POS, POS, "${{ inspect_job('foo', 'bar').id }}")
+
+    ctx = live_context_factory(client, {"test_tag"})
+    result = await expr.eval(ctx)
+    assert result == "test_id"
+    assert called
+
+
+async def test_inspect_job_no_jobs_errors(
+    client: Client, live_context_factory: LiveContextFactory
+) -> None:
+    async def fake_list(*args: Any, **kwargs: Any) -> AsyncIterator[Any]:
+        # make it async iterator:
+        for _ in range(0):
+            yield None
+
+    client.jobs.list = fake_list
+
+    expr = StrExpr(POS, POS, "${{ inspect_job('foo') }}")
+    expr_with_suffix = StrExpr(POS, POS, "${{ inspect_job('foo', 'bar') }}")
+
+    ctx = live_context_factory(client, set())
+    with pytest.raises(
+        EvalError, match=r"inspect_job\(\) did not found running job with name foo"
+    ):
+        await expr.eval(ctx)
+
+    with pytest.raises(
+        EvalError,
+        match=r"inspect_job\(\) did not found running job with name foo"
+        r" and suffix bar",
+    ):
+        await expr_with_suffix.eval(ctx)


### PR DESCRIPTION
Closes https://github.com/neuro-inc/neuro-flow/issues/232
Some questions:
- Do we need `inspect_task` analog function for the batch mode?
- Is it correct to allow inspection of only running jobs? Seems like info about finished (probably a long time ago) isn't very useful, but I'm not sure about it.