### PR TITLE
Error message is not informative in case if neuro-flow cannot find action file in github repo

### DIFF
--- a/CHANGELOG.D/294.bugfix
+++ b/CHANGELOG.D/294.bugfix
@@ -1,0 +1,1 @@
+Added proper error message for the hosted on GitHub actions, which reference is wrong (URL leads to 404).

--- a/neuro_flow/config_loader.py
+++ b/neuro_flow/config_loader.py
@@ -255,6 +255,8 @@ class LocalCL(StreamCL, abc.ABC):
             async with self._github_session.get(
                 url=f"https://api.github.com/repos/{repo}/tarball/{version}"
             ) as response:
+                if response.status == HTTPNotFound.status_code:
+                    raise ValueError(f"Cannot fetch action: either repository {repo} or tag {version} does not exists")
                 response.raise_for_status()
                 async for chunk in response.content:
                     file.write(chunk)

--- a/neuro_flow/config_loader.py
+++ b/neuro_flow/config_loader.py
@@ -5,6 +5,7 @@ import aiohttp
 import secrets
 import sys
 import tarfile
+from aiohttp.web_exceptions import HTTPNotFound
 from io import StringIO, TextIOWrapper
 from neuro_sdk import Client
 from pathlib import PureWindowsPath
@@ -256,7 +257,10 @@ class LocalCL(StreamCL, abc.ABC):
                 url=f"https://api.github.com/repos/{repo}/tarball/{version}"
             ) as response:
                 if response.status == HTTPNotFound.status_code:
-                    raise ValueError(f"Cannot fetch action: either repository {repo} or tag {version} does not exists")
+                    raise ValueError(
+                        "Cannot fetch action: "
+                        f"either repository '{repo}' or tag '{version}' does not exist"
+                    )
                 response.raise_for_status()
                 async for chunk in response.content:
                     file.write(chunk)

--- a/neuro_flow/config_loader.py
+++ b/neuro_flow/config_loader.py
@@ -255,6 +255,7 @@ class LocalCL(StreamCL, abc.ABC):
             async with self._github_session.get(
                 url=f"https://api.github.com/repos/{repo}/tarball/{version}"
             ) as response:
+                response.raise_for_status()
                 async for chunk in response.content:
                     file.write(chunk)
             file.seek(0)


### PR DESCRIPTION
This is a fix for the following bug:

1. `git clone https://github.com/neuro-actions/jupyter && cd jupyter`
2. `gsed -i "s/gh:neuro-actions\/jupyter@master*/gh:neuro-actions\/jupyter@nonexisting_branch/" .neuro/live.yaml` - change the branch of target action, hosted in the GH to non-existing one.
3. `neuro-flow run jupyter`
Get error
`ERROR: file could not be opened successfully`
instead of some more informative message.

In this implementation I just forward the message got from the git server:
`ERROR: 404, message='Not Found', url=URL('https://codeload.github.com/neuro-actions/jupyter/legacy.tar.gz/nonexisting_branch')`

If we need a different error message - let's change it.