### PR TITLE
Use ast.JobBase instead of Base for more clear error messages

### DIFF
--- a/neuro_flow/parser.py
+++ b/neuro_flow/parser.py
@@ -775,7 +775,7 @@ def parse_job(
             ctor,
             node,
             JOB_OR_ACTION,
-            ast.Base,
+            ast.JobBase,
             preprocess=select_job_or_action,
             find_res_type=find_job_type,
         ),


### PR DESCRIPTION
Related to https://github.com/neuro-inc/neuro-flow/issues/309