### PR TITLE
Add support of empty list and dict

### DIFF
--- a/CHANGELOG.D/333.feature
+++ b/CHANGELOG.D/333.feature
@@ -1,0 +1,1 @@
+Add support of empty list and dict (`[]` and `{}`) in expressions.

--- a/neuro_flow/expr.py
+++ b/neuro_flow/expr.py
@@ -679,6 +679,10 @@ def make_list(args: Tuple[Item, List[Item]]) -> ListMaker:
     return ListMaker(lst[0].start, lst[-1].end, lst)
 
 
+def make_empty_list(args: Tuple[Item, Item]) -> ListMaker:
+    return ListMaker(args[0].start, args[1].end, [])
+
+
 @dataclasses.dataclass(frozen=True)
 class DictMaker(Item):
     items: Sequence[Tuple[Item, Item]]
@@ -697,6 +701,10 @@ def make_dict(args: Tuple[Item, Item, List[Tuple[Item, Item]]]) -> DictMaker:
     if len(args) > 2:
         lst += args[2]
     return DictMaker(lst[0][0].start, lst[-1][1].end, lst)
+
+
+def make_empty_dict(args: Tuple[Item, Item]) -> DictMaker:
+    return DictMaker(args[0].start, args[0].end, [])
 
 
 def a(value: str) -> Parser:
@@ -832,7 +840,10 @@ FACTOR.define((OP_PLUS | OP_MINUS) + FACTOR >> make_unary_op_expr | ATOM_EXPR)
 
 EXPR.define(DISJUNCTION)  # Just synonym
 
-LIST_MAKER.define((LSQB + EXPR + many(COMMA + EXPR) + maybe(COMMA) + RSQB) >> make_list)
+LIST_MAKER.define(
+    (LSQB + EXPR + many(COMMA + EXPR) + maybe(COMMA) + RSQB) >> make_list
+    | (a("[") + a("]")) >> make_empty_list
+)
 
 DICT_MAKER.define(
     (
@@ -845,6 +856,7 @@ DICT_MAKER.define(
         + RBRACE
     )
     >> make_dict
+    | (a("{") + a("}")) >> make_empty_dict
 )
 
 TMPL: Final = (OPEN_TMPL + EXPR + CLOSE_TMPL) | (OPEN_TMPL2 + EXPR + CLOSE_TMPL2)

--- a/tests/unit/test_expr_eval.py
+++ b/tests/unit/test_expr_eval.py
@@ -204,10 +204,22 @@ async def test_concat_list(client: Client) -> None:
     assert [1, 2] == await expr.eval(DictContext({}, client))  # type: ignore
 
 
+async def test_concat_empty_list(client: Client) -> None:
+    pat = "${{ [1] + [] }}"
+    expr = SequenceExpr(START, Pos(0, len(pat), FNAME), pat, int)  # type: ignore
+    assert [1] == await expr.eval(DictContext({}, client))  # type: ignore
+
+
 async def test_concat_dict(client: Client) -> None:
     pat = "${{ {'a': 1} | {'b': 2} }}"
     expr = MappingExpr(START, Pos(0, len(pat), FNAME), pat, int)  # type: ignore
     assert {"a": 1, "b": 2} == await expr.eval(DictContext({}, client))  # type: ignore
+
+
+async def test_concat_empty_dict(client: Client) -> None:
+    pat = "${{ {'a': 1} | {} }}"
+    expr = MappingExpr(START, Pos(0, len(pat), FNAME), pat, int)  # type: ignore
+    assert {"a": 1} == await expr.eval(DictContext({}, client))  # type: ignore
 
 
 async def test_list_trailing_comm(client: Client) -> None:


### PR DESCRIPTION
Sometimes it is useful to be able to pass empty dict or list. For example, if actions accept any number of volumes and you want to pass zero volumes.

Also it is already supported by `json_parse("[]")` but looks hacky.