### PR TITLE
Add validation of wrong values in needs block

### DIFF
--- a/CHANGELOG.D/334.feature
+++ b/CHANGELOG.D/334.feature
@@ -1,0 +1,1 @@
+Added validation of tasks `needs` property.

--- a/neuro_flow/context.py
+++ b/neuro_flow/context.py
@@ -32,7 +32,7 @@ from yarl import URL
 
 from neuro_flow import ast
 from neuro_flow.config_loader import ConfigLoader
-from neuro_flow.expr import EnableExpr, EvalError, LiteralT, RootABC, TypeT
+from neuro_flow.expr import EnableExpr, EvalError, IdExpr, LiteralT, RootABC, TypeT
 from neuro_flow.types import AlwaysT, FullID, LocalPath, RemotePath, TaskStatus
 
 
@@ -1704,6 +1704,10 @@ class EarlyTaskGraphBuilder:
         post_tasks: List[List[EarlyPostTask]] = []
         prep_tasks: Dict[str, BaseEarlyTask] = {}
         last_needs: Set[str] = set()
+
+        # Only used for sanity checks
+        real_id_to_need_to_expr: Dict[str, Mapping[str, IdExpr]] = {}
+
         for num, ast_task in enumerate(self._ast_tasks, 1):
             assert isinstance(ast_task, (ast.Task, ast.TaskActionCall))
 
@@ -1728,7 +1732,10 @@ class EarlyTaskGraphBuilder:
                 )
 
                 task_id, real_id = await self._setup_ids(matrix_ctx, num, ast_task)
-                needs = await self._setup_needs(matrix_ctx, last_needs, ast_task)
+                needs, need_to_expr = await self._setup_needs(
+                    matrix_ctx, last_needs, ast_task
+                )
+                real_id_to_need_to_expr[real_id] = need_to_expr
 
                 base = BaseEarlyTask(
                     id=task_id,
@@ -1798,6 +1805,16 @@ class EarlyTaskGraphBuilder:
                 real_ids.add(task.real_id)
             last_needs = real_ids
 
+        # Check needs sanity
+        for prep_task in prep_tasks.values():
+            for need_id in prep_task.needs.keys():
+                id_expr = real_id_to_need_to_expr[prep_task.real_id][need_id]
+                if need_id not in prep_tasks:
+                    raise EvalError(
+                        f"Task {prep_task.real_id} needs unknown task {need_id}",
+                        id_expr.start,
+                        id_expr.end,
+                    )
         return prep_tasks
 
     async def _setup_ids(
@@ -1815,12 +1832,15 @@ class EarlyTaskGraphBuilder:
 
     async def _setup_needs(
         self, ctx: RootABC, default_needs: AbstractSet[str], ast_task: ast.TaskBase
-    ) -> Mapping[str, ast.NeedsLevel]:
+    ) -> Tuple[Mapping[str, ast.NeedsLevel], Mapping[str, IdExpr]]:
         if ast_task.needs is not None:
-            return {
-                await need.eval(ctx): level for need, level in ast_task.needs.items()
-            }
-        return {need: ast.NeedsLevel.COMPLETED for need in default_needs}
+            needs, to_expr_map = {}, {}
+            for need, level in ast_task.needs.items():
+                need_id = await need.eval(ctx)
+                needs[need_id] = level
+                to_expr_map[need_id] = need
+            return needs, to_expr_map
+        return {need: ast.NeedsLevel.COMPLETED for need in default_needs}, {}
 
 
 class TaskGraphBuilder(EarlyTaskGraphBuilder):

--- a/neuro_flow/context.py
+++ b/neuro_flow/context.py
@@ -1808,8 +1808,8 @@ class EarlyTaskGraphBuilder:
         # Check needs sanity
         for prep_task in prep_tasks.values():
             for need_id in prep_task.needs.keys():
-                id_expr = real_id_to_need_to_expr[prep_task.real_id][need_id]
                 if need_id not in prep_tasks:
+                    id_expr = real_id_to_need_to_expr[prep_task.real_id][need_id]
                     raise EvalError(
                         f"Task {prep_task.real_id} needs unknown task {need_id}",
                         id_expr.start,

--- a/neuro_flow/expr.py
+++ b/neuro_flow/expr.py
@@ -867,6 +867,8 @@ class Expr(BaseExpr[_T]):
     allow_none: ClassVar[bool] = True
     allow_expr: ClassVar[bool] = True
     type: ClassVar[Type[_T]]
+    start: Pos
+    end: Pos
     _ret: Union[None, _T]
     _pattern: Union[None, str, _T]
     _parsed: Optional[Sequence[Item]]
@@ -882,6 +884,8 @@ class Expr(BaseExpr[_T]):
             raise EvalError(str(exc), start, end)
 
     def __init__(self, start: Pos, end: Pos, pattern: Union[None, str, _T]) -> None:
+        self.start = start
+        self.end = end
         self._pattern = pattern
         # precalculated value for constant string, allows raising errors earlier
         self._ret = None

--- a/tests/unit/batch-wrong-need.yml
+++ b/tests/unit/batch-wrong-need.yml
@@ -1,0 +1,10 @@
+kind: batch
+tasks:
+  - id: task_a
+    image: ubuntu
+    preset: cpu-micro
+    bash: echo abc
+  - needs: [something_wrong]
+    image: ubuntu
+    preset: cpu-micro
+    bash: echo def

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -778,3 +778,15 @@ async def test_pipeline_with_batch_action(batch_config_loader: ConfigLoader) -> 
         "task_1": {},
         "task_2": {"task_1": ast.NeedsLevel.COMPLETED},
     }
+
+
+async def test_wrong_needs(
+    batch_config_loader: ConfigLoader,
+) -> None:
+    with pytest.raises(
+        EvalError,
+        match=r"Task task-2 needs unknown task something_wrong.*",
+    ):
+        await RunningBatchFlow.create(
+            batch_config_loader, "batch-wrong-need", "bake-id"
+        )


### PR DESCRIPTION
Before this change, it was validated implicitly in batch runner's graph construction and generated not very informative KeyError.