### PR TITLE
Fail bake on exception in executor

### DIFF
--- a/CHANGELOG.D/338.feature
+++ b/CHANGELOG.D/338.feature
@@ -1,1 +1,2 @@
-Implemented marking of bake as failed when an error happens inside of expression during the batch execution.
+Implemented marking of bake as failed when an error happens during the batch execution. If the error is caused
+because of SIGINT, the bake will be marked as cancelled instead of failed.

--- a/CHANGELOG.D/338.feature
+++ b/CHANGELOG.D/338.feature
@@ -1,0 +1,1 @@
+Implemented marking of bake as failed when an error happens inside of expression during the batch execution.

--- a/neuro_flow/batch_executor.py
+++ b/neuro_flow/batch_executor.py
@@ -541,18 +541,38 @@ class BatchExecutor:
     async def run(self) -> TaskStatus:
         with self._progress:
             try:
-                self._progress.start()
-                return await self._run()
-            except EvalError as exp:
-                self._is_cancelling = True
-                await self._stop_unfinished()
-                self._progress.log(f"[red][b]ERROR:[/b] {exp}[/red]")
-                self._progress.stop()  # Put result block below progress
-                await self._finish_run(TaskStatus.FAILED)
-                return TaskStatus.FAILED
+                result = await self._run()
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                await self._cancel_unfinished()
+                result = TaskStatus.CANCELLED
+            except Exception as exp:
+                await self.log_error(exp)
+                await self._cancel_unfinished()
+                result = TaskStatus.FAILED
+        await self._finish_run(result)
+        return result
+
+    async def log_error(self, exp: Exception) -> None:
+        if isinstance(exp, EvalError):
+            self._progress.log(f"[red][b]ERROR:[/b] {exp}[/red]")
+        else:
+            # Looks like this is some bug in our code, so we should print stacktrace
+            # for easier debug
+            self._progress.console.print_exception()
+            self._progress.log(
+                "[red][b]ERROR:[/b] Some unknown error happened. Please report "
+                "an issue to https://github.com/neuro-inc/neuro-flow/issues/new "
+                "with traceback printed above.[/red]"
+            )
 
     async def _run(self) -> TaskStatus:
         await self._load_previous_run()
+
+        if self._attempt.result in TERMINATED_TASK_STATUSES:
+            # If attempt is already terminated, just clean up tasks
+            # and exit
+            await self._cancel_unfinished()
+            return self._attempt.result
 
         while await self._should_continue():
             for full_id, flow in self._graphs.get_ready_with_meta():
@@ -580,14 +600,11 @@ class BatchExecutor:
                 await self._refresh_attempt()
 
                 if not ok or self._attempt.result == TaskStatus.CANCELLED:
-                    self._is_cancelling = True
-                    await self._stop_unfinished()
+                    await self._cancel_unfinished()
 
             await asyncio.sleep(self._polling_timeout)
 
-        attempt_status = self._accumulate_result()
-        await self._finish_run(attempt_status)
-        return attempt_status
+        return self._accumulate_result()
 
     async def _finish_run(self, attempt_status: TaskStatus) -> None:
         if self._attempt.result not in TERMINATED_TASK_STATUSES:
@@ -599,7 +616,8 @@ class BatchExecutor:
             justify="center",
         )
 
-    async def _stop_unfinished(self) -> None:
+    async def _cancel_unfinished(self) -> None:
+        self._is_cancelling = True
         for full_id, st in self._tasks_mgr.unfinished_tasks.items():
             task = await self._get_task(full_id)
             if task.enable is not AlwaysT():

--- a/neuro_flow/batch_runner.py
+++ b/neuro_flow/batch_runner.py
@@ -160,14 +160,14 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
     async def _run_locals(
         self,
         data: ExecutorData,
-    ) -> None:
+    ) -> TaskStatus:
         async with LocalsBatchExecutor.create(
             self._console,
             data,
             self._client,
             self._storage,
         ) as executor:
-            await executor.run()
+            return await executor.run()
 
     async def bake(
         self,
@@ -184,7 +184,9 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
 
     async def _run_bake(self, data: ExecutorData, local_executor: bool) -> None:
         self._console.rule("Run local actions")
-        await self._run_locals(data)
+        locals_result = await self._run_locals(data)
+        if locals_result != TaskStatus.SUCCEEDED:
+            return
         self._console.rule("Run main actions")
         if local_executor:
             self._console.log(f"[bright_black]Using local executor")

--- a/neuro_flow/batch_runner.py
+++ b/neuro_flow/batch_runner.py
@@ -197,7 +197,6 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
             await run_subproc(
                 "neuro",
                 "run",
-                "--restart=on-failure",
                 "--pass-config",
                 f"--tag=project:{data.project}",
                 f"--tag=flow:{data.batch}",

--- a/tests/unit/batch-bad-eval.yml
+++ b/tests/unit/batch-bad-eval.yml
@@ -1,0 +1,5 @@
+kind: batch
+tasks:
+  - image: ${{ something.wrong }}
+    preset: cpu-micro
+    bash: echo abc

--- a/tests/unit/local_actions/bad-local.yml
+++ b/tests/unit/local_actions/bad-local.yml
@@ -1,0 +1,4 @@
+kind: local
+author: Roman Skurikhin
+descr: Just fails with bad expr
+cmd: ${{ something.wrong }}

--- a/tests/unit/local_actions/call-bad-local.yml
+++ b/tests/unit/local_actions/call-bad-local.yml
@@ -1,0 +1,8 @@
+kind: batch
+tasks:
+- id: bad
+  action: ws:bad-local
+- id: remote_task
+  needs: [bad]
+  image: ubuntu
+  bash: echo "Should never happen"

--- a/tests/unit/test_batch_exector.py
+++ b/tests/unit/test_batch_exector.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from rich import get_console
 from tempfile import TemporaryDirectory
 from typing import (
+    Any,
     AsyncIterator,
     Awaitable,
     Callable,
@@ -468,6 +469,11 @@ class FakeForceStopException(BaseException):
     pass
 
 
+def run_in_loop(coro: Awaitable[Any]) -> Any:
+    loop = asyncio.new_event_loop()
+    return loop.run_until_complete(coro)
+
+
 async def test_complex_seq_continue(
     jobs_mock: JobsMock,
     batch_storage: Storage,
@@ -477,7 +483,7 @@ async def test_complex_seq_continue(
     data = await batch_runner._setup_exc_data("batch-complex-seq")
     # Use separate thread to allow force abort
     executor_task = asyncio.get_event_loop().run_in_executor(
-        None, asyncio.run, start_executor(data)
+        None, run_in_loop, start_executor(data)
     )
 
     await jobs_mock.get_task("task_1_a")
@@ -528,7 +534,7 @@ async def test_complex_seq_continue_2(
     data = await batch_runner._setup_exc_data("batch-complex-seq")
     # Use separate thread to allow force abort
     executor_task = asyncio.get_event_loop().run_in_executor(
-        None, asyncio.run, start_executor(data)
+        None, run_in_loop, start_executor(data)
     )
 
     await jobs_mock.get_task("task_1_a")


### PR DESCRIPTION
Currently, if the executor fails because of the "error", it is almost always stuck in an infinite loop of restarts. I used manually cancels the job, the bake remains in a "running" state, and it is very inconvenient.
So here I stop the execution if an error happens.
If it was flakiness, the user should use the `restart` command.
