### PR TITLE
Mark attempt as running from executor

### DIFF
--- a/neuro_flow/batch_executor.py
+++ b/neuro_flow/batch_executor.py
@@ -850,7 +850,7 @@ class BatchExecutor:
         job_id = os.environ.get("NEURO_JOB_ID")
         if job_id:
             # store job id as executor id
-            await self._storage.store_executor_id(self._attempt, job_id)
+            await self._storage.mark_attempt_running(self._attempt, job_id)
 
         if self._attempt.result in TERMINATED_TASK_STATUSES:
             # If attempt is already terminated, just clean up tasks

--- a/reference/cli.md
+++ b/reference/cli.md
@@ -205,7 +205,7 @@ neuro-flow clean [OPTIONS] VOLUME
 
 Clear cache.
 
-Use `neuro-flow clear-cache <BATCH>` for cleaning up the cache for BATCH; Use `neuro-flow clear-cache <BATCH> <TASK_ID>` for cleaning up the cache for TASK\_ID in BATCH;
+Use `neuro-flow clear-cache <BATCH>` for cleaning up the cache for BATCH; Use `neuro-flow clear-cache <BATCH> <TASK_ID>` for cleaning up the cache for TASK_ID in BATCH;
 
 `neuro-flow clear-cache ALL` clears all caches.
 


### PR DESCRIPTION
Solves an issue reported by synthesis when a bake switches from `pending` directly to `succeeded`.