### PR TITLE
Rename inherits to mixins

### DIFF
--- a/CHANGELOG.D/560.feature
+++ b/CHANGELOG.D/560.feature
@@ -1,0 +1,1 @@
+Renamed `inherits` yaml property to `mixins`.

--- a/neuro_flow/ast.py
+++ b/neuro_flow/ast.py
@@ -170,7 +170,7 @@ class JobMixin(WithSpecifiedFields, Base):
     port_forward: Optional[BaseExpr[SequenceT]] = field(metadata={"allow_none": True})
     multi: SimpleOptBoolExpr
     params: Optional[Mapping[str, Param]] = field(metadata={"allow_none": True})
-    inherits: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
+    mixins: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
 
 
 @dataclass(frozen=True)
@@ -181,7 +181,7 @@ class Job(ExecUnit, WithSpecifiedFields, JobBase):
     browse: OptBoolExpr
     port_forward: Optional[BaseExpr[SequenceT]] = field(metadata={"allow_none": True})
     multi: SimpleOptBoolExpr
-    inherits: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
+    mixins: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
 
 
 class NeedsLevel(enum.Enum):
@@ -209,7 +209,7 @@ class TaskBase(Base):
 
 @dataclass(frozen=True)
 class Task(ExecUnit, WithSpecifiedFields, TaskBase):
-    inherits: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
+    mixins: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
 
 
 @dataclass(frozen=True)
@@ -233,7 +233,7 @@ class TaskMixin(WithSpecifiedFields, Base):
     strategy: Optional[Strategy] = field(metadata={"allow_none": True})
     enable: EnableExpr = field(metadata={"default_expr": "${{ success() }}"})
     cache: Optional[Cache] = field(metadata={"allow_none": True})
-    inherits: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
+    mixins: Optional[Sequence[StrExpr]] = field(metadata={"allow_none": True})
 
 
 @dataclass(frozen=True)

--- a/neuro_flow/parser.py
+++ b/neuro_flow/parser.py
@@ -642,7 +642,7 @@ JOB_MIXIN = {
     "port_forward": ExprOrSeq(PortPairExpr, port_pair_item),
     "multi": SimpleOptBoolExpr,
     "params": None,
-    "inherits": SimpleSeq(StrExpr),
+    "mixins": SimpleSeq(StrExpr),
 }
 
 JOB: Dict[str, Any] = {
@@ -652,7 +652,7 @@ JOB: Dict[str, Any] = {
     "port_forward": ExprOrSeq(PortPairExpr, port_pair_item),
     "multi": SimpleOptBoolExpr,
     "params": None,
-    "inherits": SimpleSeq(StrExpr),
+    "mixins": SimpleSeq(StrExpr),
 }
 
 JOB_ACTION_CALL = {
@@ -806,7 +806,7 @@ TASK_BASE = {
 TASK: Mapping[str, Any] = {
     **TASK_BASE,
     **EXEC_UNIT,
-    "inherits": SimpleSeq(StrExpr),
+    "mixins": SimpleSeq(StrExpr),
 }
 
 TASK_MIXIN: Mapping[str, Any] = {
@@ -815,7 +815,7 @@ TASK_MIXIN: Mapping[str, Any] = {
     "strategy": None,
     "enable": EnableExpr,
     "cache": None,
-    "inherits": SimpleSeq(StrExpr),
+    "mixins": SimpleSeq(StrExpr),
 }
 
 

--- a/reference/mixins.md
+++ b/reference/mixins.md
@@ -13,13 +13,13 @@ mixins:
 ...
 ```
 
-Mixins can define the same properties as "job" and "task" do, except for the "id" field in batch mode. To apply a mixin, use the `inherits` property:
+Mixins can define the same properties as "job" and "task" do, except for the "id" field in batch mode. To apply a mixin, use the `mixins` property:
 
 ```yaml
 ...
 jobs:
   test_a:
-    inherits: [ credentials ]
+    mixins: [ credentials ]
 ...
 ```
 
@@ -35,10 +35,10 @@ mixins:
     image: example_mix2
 jobs:
   job1:
-    inherits: [mix1, mix2]
+    mixins: [mix1, mix2]
     image: example
   job2:
-    inherits: [mix1, mix2]
+    mixins: [mix1, mix2]
 ```
 
 In this case, `job1` will use the `example` image and `job2` will use the `example_mix2` image.
@@ -54,7 +54,7 @@ mixins:
     env:
       TEST: 1
   mix2:
-    inherits: [ mix1 ]
+    mixins: [ mix1 ]
     image: example
 ``` ([#498](https://github.com/neuro-inc/neuro-flow/issues/498))
 ```

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ async_exit_stack==1.0.1; python_version<"3.7"
 backports-datetime-fromisoformat==1.0.0; python_version<"3.7"
 click==8.0.1
 dataclasses==0.7; python_version<"3.7"
-funcparserlib==0.3.6
+funcparserlib==1.0.0a0
 graphviz==0.17
 humanize==3.11.0
 neuro-cli==21.9.2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     install_requires=[
         "neuro-cli>=21.8.27",
         "pyyaml>=5.4",
-        "funcparserlib>=0.3",
+        "funcparserlib>=1.0.0a0",
         'dataclasses>=0.5; python_version<"3.7"',
         "humanize>=0.5.1",
         'backports-datetime-fromisoformat>=1.0.0; python_version<"3.7"',

--- a/tests/unit/batch-mixin.yml
+++ b/tests/unit/batch-mixin.yml
@@ -4,8 +4,8 @@ mixins:
     image: ubuntu
     preset: cpu-micro
 tasks:
-  - inherits: [basic]
+  - mixins: [basic]
     bash: echo abc
 
-  - inherits: [basic]
+  - mixins: [basic]
     bash: echo def

--- a/tests/unit/batch-sub-mixin.yml
+++ b/tests/unit/batch-sub-mixin.yml
@@ -5,7 +5,7 @@ mixins:
       env1: val-mixin1-1
       env2: val-mixin1-2
   envs2:
-    inherits: [envs1]
+    mixins: [envs1]
     env:
       env2: val-mixin2-2
       env3: val-mixin2-3
@@ -13,8 +13,8 @@ mixins:
     image: ubuntu
     preset: cpu-micro
 tasks:
-  - inherits: [basic, envs1]
+  - mixins: [basic, envs1]
     bash: echo abc
 
-  - inherits: [basic, envs2]
+  - mixins: [basic, envs2]
     bash: echo def

--- a/tests/unit/batch_mixins/batch-module-uses-mixin.yml
+++ b/tests/unit/batch_mixins/batch-module-uses-mixin.yml
@@ -1,5 +1,5 @@
 kind: batch
 tasks:
 - id: task_1
-  inherits: [basic]
+  mixins: [basic]
   bash: echo abc

--- a/tests/unit/hash_files/requirements/base.txt
+++ b/tests/unit/hash_files/requirements/base.txt
@@ -2,7 +2,7 @@
 async_exit_stack==1.0.1; python_version<"3.7"
 backports-datetime-fromisoformat==1.0.0; python_version<"3.7"
 dataclasses==0.7; python_version<"3.7"
-funcparserlib==0.3.6
+funcparserlib==1.0.0a0
 humanize==3.0.0
 neuro-extras==20.9.30.2
 neuromation==20.9.24

--- a/tests/unit/hash_files/requirements/base.txt
+++ b/tests/unit/hash_files/requirements/base.txt
@@ -2,7 +2,7 @@
 async_exit_stack==1.0.1; python_version<"3.7"
 backports-datetime-fromisoformat==1.0.0; python_version<"3.7"
 dataclasses==0.7; python_version<"3.7"
-funcparserlib==1.0.0a0
+funcparserlib==0.3.6
 humanize==3.0.0
 neuro-extras==20.9.30.2
 neuromation==20.9.24

--- a/tests/unit/live-full.yml
+++ b/tests/unit/live-full.yml
@@ -42,7 +42,7 @@ mixins:
 jobs:
   test_a:
     name: job-name
-    inherits: [ envs ]
+    mixins: [ envs ]
     image: ${{ images.image_a.ref }}
     preset: cpu-micro
     schedule_timeout: 1d2h3m4s

--- a/tests/unit/live-mixins.yml
+++ b/tests/unit/live-mixins.yml
@@ -27,15 +27,15 @@ mixins:
 jobs:
   test:
     name: job-name
-    inherits: [ envs1, envs2, preset, image ]
+    mixins: [ envs1, envs2, preset, image ]
     env:
       env1: val1
       env2: val2
   test2:
     name: job-name
-    inherits: [ image, image2 ]
+    mixins: [ image, image2 ]
   test3:
     name: job-name
-    inherits: [ image, volumes1, volumes2 ]
+    mixins: [ image, volumes1, volumes2 ]
   test4:
-    inherits: [ image, expression ]
+    mixins: [ image, expression ]

--- a/tests/unit/live-sub-mixins.yml
+++ b/tests/unit/live-sub-mixins.yml
@@ -5,7 +5,7 @@ mixins:
       env1: val-mixin1-1
       env2: val-mixin1-2
   envs2:
-    inherits: [envs1]
+    mixins: [envs1]
     env:
       env2: val-mixin2-2
       env3: val-mixin2-3
@@ -13,4 +13,4 @@ jobs:
   test:
     name: job-name
     image: ubuntu
-    inherits: [ envs2]
+    mixins: [ envs2]

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -73,7 +73,7 @@ def test_parse_live_action(assets: LocalPath) -> None:
             Pos(11, 2, config_file),
             Pos(13, 0, config_file),
             _specified_fields={"cmd", "image"},
-            inherits=None,
+            mixins=None,
             name=OptStrExpr(Pos(3, 4, config_file), Pos(5, 0, config_file), None),
             image=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "ubuntu"),
             preset=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
@@ -263,7 +263,7 @@ def test_parse_batch_action(assets: LocalPath) -> None:
                 Pos(36, 2, config_file),
                 Pos(40, 0, config_file),
                 _specified_fields={"needs", "image", "cmd", "id"},
-                inherits=None,
+                mixins=None,
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
@@ -313,7 +313,7 @@ def test_parse_batch_action(assets: LocalPath) -> None:
                 Pos(40, 2, config_file),
                 Pos(43, 0, config_file),
                 _specified_fields={"image", "cmd", "id"},
-                inherits=None,
+                mixins=None,
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(

--- a/tests/unit/test_batch_parser.py
+++ b/tests/unit/test_batch_parser.py
@@ -197,7 +197,7 @@ def test_parse_minimal(assets: pathlib.Path) -> None:
                     "id",
                     "volumes",
                 },
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "test_a"),
                 title=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "Batch title"
@@ -325,7 +325,7 @@ def test_parse_seq(assets: pathlib.Path) -> None:
                 _start=Pos(2, 4, config_file),
                 _end=Pos(6, 2, config_file),
                 _specified_fields={"preset", "cmd", "image"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs=None,
@@ -375,7 +375,7 @@ def test_parse_seq(assets: pathlib.Path) -> None:
                 _start=Pos(6, 4, config_file),
                 _end=Pos(9, 0, config_file),
                 _specified_fields={"preset", "cmd", "image"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs=None,
@@ -456,7 +456,7 @@ def test_parse_needs(assets: pathlib.Path) -> None:
                 _start=Pos(2, 4, config_file),
                 _end=Pos(7, 2, config_file),
                 _specified_fields={"cmd", "image", "id", "preset"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "task_a"),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs=None,
@@ -506,7 +506,7 @@ def test_parse_needs(assets: pathlib.Path) -> None:
                 _start=Pos(7, 4, config_file),
                 _end=Pos(11, 0, config_file),
                 _specified_fields={"needs", "image", "cmd", "preset"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs={
@@ -591,7 +591,7 @@ def test_parse_needs_dict(assets: pathlib.Path) -> None:
                 _start=Pos(2, 4, config_file),
                 _end=Pos(7, 2, config_file),
                 _specified_fields={"preset", "image", "cmd", "id"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "task_a"),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs=None,
@@ -641,7 +641,7 @@ def test_parse_needs_dict(assets: pathlib.Path) -> None:
                 _start=Pos(7, 4, config_file),
                 _end=Pos(12, 0, config_file),
                 _specified_fields={"preset", "image", "cmd", "needs"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs={
@@ -728,7 +728,7 @@ def test_parse_matrix(assets: pathlib.Path) -> None:
                 _start=Pos(2, 4, config_file),
                 _end=Pos(14, 0, config_file),
                 _specified_fields={"strategy", "image", "cmd"},
-                inherits=None,
+                mixins=None,
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
@@ -885,7 +885,7 @@ def test_parse_matrix_with_strategy(assets: pathlib.Path) -> None:
                 _start=Pos(8, 4, config_file),
                 _end=Pos(25, 2, config_file),
                 _specified_fields={"image", "strategy", "cmd", "cache"},
-                inherits=None,
+                mixins=None,
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
@@ -991,7 +991,7 @@ def test_parse_matrix_with_strategy(assets: pathlib.Path) -> None:
                 Pos(25, 4, config_file),
                 Pos(28, 0, config_file),
                 _specified_fields={"id", "image", "cmd"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(
                     Pos(25, 8, config_file), Pos(25, 14, config_file), "simple"
                 ),
@@ -1154,7 +1154,7 @@ def test_parse_args(assets: pathlib.Path) -> None:
                     config_file,
                 ),
                 _specified_fields={"image", "cmd"},
-                inherits=None,
+                mixins=None,
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
@@ -1233,7 +1233,7 @@ def test_parse_enable(assets: pathlib.Path) -> None:
                 _start=Pos(2, 4, config_file),
                 _end=Pos(6, 2, config_file),
                 _specified_fields={"cmd", "id", "preset", "image"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "task_a"),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs=None,
@@ -1283,7 +1283,7 @@ def test_parse_enable(assets: pathlib.Path) -> None:
                 _start=Pos(6, 4, config_file),
                 _end=Pos(11, 0, config_file),
                 _specified_fields={"enable", "image", "needs", "cmd", "preset"},
-                inherits=None,
+                mixins=None,
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 title=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 needs={
@@ -1367,7 +1367,7 @@ def test_parse_mixin(assets: pathlib.Path) -> None:
                 Pos(3, 4, config_file),
                 Pos(5, 0, config_file),
                 _specified_fields={"image", "preset"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file),
@@ -1417,8 +1417,8 @@ def test_parse_mixin(assets: pathlib.Path) -> None:
             ast.Task(
                 _start=Pos(6, 4, config_file),
                 _end=Pos(9, 2, config_file),
-                _specified_fields={"inherits", "cmd"},
-                inherits=[
+                _specified_fields={"mixins", "cmd"},
+                mixins=[
                     StrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "basic")
                 ],
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
@@ -1465,8 +1465,8 @@ def test_parse_mixin(assets: pathlib.Path) -> None:
             ast.Task(
                 _start=Pos(9, 4, config_file),
                 _end=Pos(11, 0, config_file),
-                _specified_fields={"inherits", "cmd"},
-                inherits=[
+                _specified_fields={"mixins", "cmd"},
+                mixins=[
                     StrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "basic")
                 ],
                 id=OptIdExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),

--- a/tests/unit/test_live_parser.py
+++ b/tests/unit/test_live_parser.py
@@ -59,7 +59,7 @@ def test_parse_minimal(assets: pathlib.Path) -> None:
                 Pos(3, 4, config_file),
                 Pos(5, 0, config_file),
                 _specified_fields={"cmd", "image"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(3, 4, config_file), Pos(5, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "ubuntu"
@@ -136,7 +136,7 @@ def test_parse_params(assets: pathlib.Path) -> None:
                 Pos(3, 4, config_file),
                 Pos(11, 0, config_file),
                 _specified_fields={"cmd", "image", "params"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(3, 4, config_file), Pos(5, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "ubuntu"
@@ -378,7 +378,7 @@ def test_parse_full(assets: pathlib.Path) -> None:
                 Pos(38, 4, config_file),
                 Pos(41, 0, config_file),
                 _specified_fields={"env"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file),
@@ -458,12 +458,12 @@ def test_parse_full(assets: pathlib.Path) -> None:
                     "name",
                     "tags",
                     "image",
-                    "inherits",
+                    "mixins",
                     "browse",
                     "volumes",
                     "entrypoint",
                 },
-                inherits=[
+                mixins=[
                     StrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), "envs")
                 ],
                 name=OptStrExpr(
@@ -729,7 +729,7 @@ def test_parse_full_exprs(assets: pathlib.Path) -> None:
                     "volumes",
                     "detach",
                 },
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "job-name"
                 ),
@@ -834,7 +834,7 @@ def test_parse_bash(assets: pathlib.Path) -> None:
                 Pos(3, 4, config_file),
                 Pos(7, 0, config_file),
                 _specified_fields={"cmd", "image"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "ubuntu"
@@ -913,7 +913,7 @@ def test_parse_python(assets: pathlib.Path) -> None:
                 Pos(3, 4, config_file),
                 Pos(7, 0, config_file),
                 _specified_fields={"cmd", "image"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "ubuntu"
@@ -1040,7 +1040,7 @@ def test_parse_multi(assets: pathlib.Path) -> None:
                 Pos(3, 4, config_file),
                 Pos(6, 0, config_file),
                 _specified_fields={"cmd", "multi", "image"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(3, 4, config_file), Pos(5, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "ubuntu"
@@ -1117,7 +1117,7 @@ def test_parse_explicit_flow_id(assets: pathlib.Path) -> None:
                 Pos(4, 4, config_file),
                 Pos(6, 0, config_file),
                 _specified_fields={"cmd", "image"},
-                inherits=None,
+                mixins=None,
                 name=OptStrExpr(Pos(0, 0, config_file), Pos(0, 0, config_file), None),
                 image=OptStrExpr(
                     Pos(0, 0, config_file), Pos(0, 0, config_file), "ubuntu"


### PR DESCRIPTION
In general, we need to support both options at least for some time for backward compatibility. But I guess no one was tried to integrate the mixins feature, so maybe it is ok to just rename. @asvetlov what do you think?