### PR TITLE
Nested subgraphs while rendering graph

### DIFF
--- a/CHANGELOG.D/1338.feature.md
+++ b/CHANGELOG.D/1338.feature.md
@@ -1,0 +1,1 @@
+Added programatic API wrapper for apolo-flow: machine-readable facade for Flow project.

--- a/CHANGELOG.D/910.bugfix.md
+++ b/CHANGELOG.D/910.bugfix.md
@@ -1,0 +1,1 @@
+Fix rendering nested subgraphs in batch graph output.

--- a/src/apolo_flow/batch_runner.py
+++ b/src/apolo_flow/batch_runner.py
@@ -694,6 +694,7 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
                 color = None
 
             if task_id in graphs:
+                # task_id is a subgraph
                 lhead = "cluster_" + tgt
                 with dot.subgraph(name=lhead) as subdot:
                     subdot.attr(label=f"{name}")
@@ -714,11 +715,15 @@ class BatchRunner(AsyncContextManager["BatchRunner"]):
             for dep in deps:
                 src = ".".join(dep)
                 if src in anchors:
-                    # src is a subgraph
-                    ltail = "cluster_" + src
-                    src = anchors[src]
+                    while src in anchors:
+                        # src is a subgraph
+                        ltail = "cluster_" + ".".join(dep)
+                        src = anchors[src]
                 else:
                     ltail = None
+                while tgt in anchors:
+                    # tgt is a subgraph
+                    tgt = anchors[tgt]
                 dot.edge(src, tgt, ltail=ltail, lhead=lhead)
 
     async def logs(

--- a/tests/unit/test_batch_runner.py
+++ b/tests/unit/test_batch_runner.py
@@ -5,9 +5,11 @@ import sys
 import textwrap
 from apolo_sdk import Client
 from contextlib import asynccontextmanager
+from graphviz import Digraph
 from typing import AsyncContextManager, AsyncIterator, Callable, Mapping
 
 from apolo_flow.batch_runner import (
+    BatchRunner,
     ImageRefNotUniqueError,
     build_graphs,
     check_image_refs_unique,
@@ -149,6 +151,42 @@ async def test_early_graph(batch_cl_factory: BatchClFactory) -> None:
                 },
             },
         }
+
+
+async def test_render_graph_with_nested_subgraphs() -> None:
+    class Runner:
+        async def _subgraph(self, *args: object) -> None:
+            await BatchRunner._subgraph(self, *args)  # type: ignore[arg-type]
+
+    graphs = {
+        (): {
+            ("first",): set(),
+            ("second",): {("first",)},
+        },
+        ("first",): {
+            ("first", "nested"): set(),
+        },
+        ("first", "nested"): {
+            ("first", "nested", "leaf"): set(),
+        },
+        ("second",): {
+            ("second", "nested"): set(),
+        },
+        ("second", "nested"): {
+            ("second", "nested", "leaf"): set(),
+        },
+    }
+
+    dot = Digraph("test")
+    dot.attr(compound="true")
+    dot.node_attr = {"style": "filled"}
+
+    await Runner()._subgraph(dot, graphs, (), {}, {})
+
+    assert (
+        '\t"first.nested.leaf" -> "second.nested.leaf" '
+        "[lhead=cluster_second ltail=cluster_first]"
+    ) in dot.source
 
 
 async def test_check_image_refs_unique(batch_cl_factory: BatchClFactory) -> None:


### PR DESCRIPTION
### Bug description
When you have 2+folded actions in bakes, NF cannot properly render the bake.

Compare expected and actual batch graphs:
<details>

Expected result
![fixed](https://user-images.githubusercontent.com/32543098/188218219-17955c34-e804-411f-8b29-c6eafff676d2.svg)

Actual result
<img width="1563" alt="image" src="https://user-images.githubusercontent.com/32543098/188218427-d20ced8d-a762-4a3d-bf89-4e4b6e037eb9.png">

</details>

### PR description
In this PR we handle cases when either src or dst nodes are actually subgraphs.

**But**

AFAIU, we rely on subgraphs ordering to properly render dot file. During the debug, I've found out that bake storage responds with the altered subgraphs ordering:

<details>

What we send:
<img width="1640" alt="image" src="https://user-images.githubusercontent.com/32543098/188219783-fea870d2-3ff9-4055-b386-9309e6e6cd2f.png">

We get back (when performing `neuro-flow bake inspect`):
<img width="1637" alt="image" src="https://user-images.githubusercontent.com/32543098/188219865-f5ee742a-85f3-46c6-878b-e833401982a4.png">

</details>

This breaks the algorithm of Graphviz dotfile rendering (`batch_runner._subgraph`). One thing we could do is to enforce elements ordering, but maybe there is some crucial peace I'm missing.  @romasku , wdyt on this?